### PR TITLE
Fix HTTP(S) health probes on Azure when using K8s ≥1.24

### DIFF
--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -14,6 +14,11 @@ external-dns:
     godaddy-api-secret:
       "$GODADDY_SECRET_KEY" # need to modify var name here and in dns-creds secret in case you change 'provider'
   extraEnvVarsSecret: dns-creds
+ingress-nginx:
+  controller:
+    service:
+      annotations:
+        service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/healthz"
 
 infra:
   enabled: false


### PR DESCRIPTION
Starting from Kubernetes 1.24, the Azure cloud-controller-manager tries to use the [appProtocol as default for the health probes of a new load balancer](https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/site/content/en/topics/loadbalancer.md#custom-load-balancer-health-probe).

As the NGINX Ingress Controller defines HTTP and HTTPS as the appProtocol, this creates HTTP and HTTPS probes (for a L4 load balancer, not L7).

However, this creates an interesting issue. An HTTP(S) probe fails whenever a non-200 status is returned. By default, the NGINX controller does not deploy any content on the LB IP host, which causes NGINX to response with a 404 to the health probes from Azure. Now Azure thinks our NGINX is down and doesn't route traffic to it, essentially null-routing all incoming traffic on port 80/443 on this LB IP. This affects the Ingresses created by our deployments, as they will not be reachable from the outside.

For health checks, NGINX specifically has an /healthz endpoint like many K8s aware applications do. But by default, the Azure health probe checks for /. Luckily, we can use an annotation to point the health probe to /healthz, which satisfies the health probe and makes the LB route traffic to our NGINX.

As always with minor fixes, this took a few hours to debug. The more you know, I guess...

Our current deployments on our testing cluster did not have this issue as they were deployed using K8s 1.23, which uses simple TCP health probes instead of HTTP(S) ones. But since now our default is K8s 1.24, we should add this to our deployments.

Fun fact, this also affected AKS: https://learn.microsoft.com/en-us/answers/questions/1008699/aks-124-ingress-not-exposed.html